### PR TITLE
Requesting approval to deploy image 1-4508a6c

### DIFF
--- a/deploy/deploy.auto.tfvars
+++ b/deploy/deploy.auto.tfvars
@@ -1,4 +1,4 @@
 kube_config_context = "devops-interview"
 deployment_yaml     = "manifests/deploy.yaml"
-image_name          = "docker.io/edamsoft/turo:1-4508a6c"
+image_name          ="docker.io/edamsoft/turo:1-4508a6c"
 kube_namespace      = "eric-testing"


### PR DESCRIPTION
Please review terraform plan for branch deploy_1-4508a6c:
 
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # kubernetes_manifest.turo-test-deployment will be created
  + resource "kubernetes_manifest" "turo-test-deployment" {
      + manifest = {
          + apiVersion = "apps/v1"
          + kind       = "Deployment"
          + metadata   = {
              + annotations = {
                  + env = "dev"
                }
              + name        = "turo-test"
              + namespace   = "eric-testing"
            }
          + spec       = {
              + replicas = 1
              + selector = {
                  + matchLabels = {
                      + app = "turo-test"
                    }
                }
              + template = {
                  + metadata = {
                      + labels = {
                          + app = "turo-test"
                        }
                    }
                  + spec     = {
                      + containers = [
                          + {
                              + image = "docker.io/edamsoft/turo:1-4508a6c"
                              + name  = "turo-test"
                            },
                        ]
                    }
                }
            }
        }
      + object   = {
          + apiVersion = "apps/v1"
          + kind       = "Deployment"
          + metadata   = {
              + annotations                = (known after apply)
              + clusterName                = (known after apply)
              + creationTimestamp          = (known after apply)
              + deletionGracePeriodSeconds = (known after apply)
              + deletionTimestamp          = (known after apply)
              + finalizers                 = (known after apply)
              + generateName               = (known after apply)
              + generation                 = (known after apply)
              + labels                     = (known after apply)
              + managedFields              = (known after apply)
              + name                       = "turo-test"
              + namespace                  = "eric-testing"
              + ownerReferences            = (known after apply)
              + resourceVersion            = (known after apply)
              + selfLink                   = (known after apply)
              + uid                        = (known after apply)
            }
          + spec       = {
              + minReadySeconds         = (known after apply)
              + paused                  = (known after apply)
              + progressDeadlineSeconds = (known after apply)
              + replicas                = 1
              + revisionHistoryLimit    = (known after apply)
              + selector                = {
                  + matchExpressions = (known after apply)
                  + matchLabels      = {
                      + "app" = "turo-test"
                    }
                }
              + strategy                = {
                  + rollingUpdate = {
                      + maxSurge       = (known after apply)
                      + maxUnavailable = (known after apply)
                    }
                  + type          = (known after apply)
                }
              + template                = {
                  + metadata = {
                      + annotations                = (known after apply)
                      + clusterName                = (known after apply)
                      + creationTimestamp          = (known after apply)
                      + deletionGracePeriodSeconds = (known after apply)
                      + deletionTimestamp          = (known after apply)
                      + finalizers                 = (known after apply)
                      + generateName               = (known after apply)
                      + generation                 = (known after apply)
                      + labels                     = {
                          + "app" = "turo-test"
                        }
                      + managedFields              = (known after apply)
                      + name                       = (known after apply)
                      + namespace                  = (known after apply)
                      + ownerReferences            = (known after apply)
                      + resourceVersion            = (known after apply)
                      + selfLink                   = (known after apply)
                      + uid                        = (known after apply)
                    }
                  + spec     = {
                      + activeDeadlineSeconds         = (known after apply)
                      + affinity                      = {
                          + nodeAffinity    = {
                              + preferredDuringSchedulingIgnoredDuringExecution = (known after apply)
                              + requiredDuringSchedulingIgnoredDuringExecution  = {
                                  + nodeSelectorTerms = (known after apply)
                                }
                            }
                          + podAffinity     = {
                              + preferredDuringSchedulingIgnoredDuringExecution = (known after apply)
                              + requiredDuringSchedulingIgnoredDuringExecution  = (known after apply)
                            }
                          + podAntiAffinity = {
                              + preferredDuringSchedulingIgnoredDuringExecution = (known after apply)
                              + requiredDuringSchedulingIgnoredDuringExecution  = (known after apply)
                            }
                        }
                      + automountServiceAccountToken  = (known after apply)
                      + containers                    = [
                          + {
                              + args                     = (known after apply)
                              + command                  = (known after apply)
                              + env                      = (known after apply)
                              + envFrom                  = (known after apply)
                              + image                    = "docker.io/edamsoft/turo:1-4508a6c"
                              + imagePullPolicy          = (known after apply)
                              + lifecycle                = {
                                  + postStart = {
                                      + exec      = {
                                          + command = (known after apply)
                                        }
                                      + httpGet   = {
                                          + host        = (known after apply)
                                          + httpHeaders = (known after apply)
                                          + path        = (known after apply)
                                          + port        = (known after apply)
                                          + scheme      = (known after apply)
                                        }
                                      + tcpSocket = {
                                          + host = (known after apply)
                                          + port = (known after apply)
                                        }
                                    }
                                  + preStop   = {
                                      + exec      = {
                                          + command = (known after apply)
                                        }
                                      + httpGet   = {
                                          + host        = (known after apply)
                                          + httpHeaders = (known after apply)
                                          + path        = (known after apply)
                                          + port        = (known after apply)
                                          + scheme      = (known after apply)
                                        }
                                      + tcpSocket = {
                                          + host = (known after apply)
                                          + port = (known after apply)
                                        }
                                    }
                                }
                              + livenessProbe            = {
                                  + exec                          = {
                                      + command = (known after apply)
                                    }
                                  + failureThreshold              = (known after apply)
                                  + grpc                          = {
                                      + port    = (known after apply)
                                      + service = (known after apply)
                                    }
                                  + httpGet                       = {
                                      + host        = (known after apply)
                                      + httpHeaders = (known after apply)
                                      + path        = (known after apply)
                                      + port        = (known after apply)
                                      + scheme      = (known after apply)
                                    }
                                  + initialDelaySeconds           = (known after apply)
                                  + periodSeconds                 = (known after apply)
                                  + successThreshold              = (known after apply)
                                  + tcpSocket                     = {
                                      + host = (known after apply)
                                      + port = (known after apply)
                                    }
                                  + terminationGracePeriodSeconds = (known after apply)
                                  + timeoutSeconds                = (known after apply)
                                }
                              + name                     = "turo-test"
                              + ports                    = (known after apply)
                              + readinessProbe           = {
                                  + exec                          = {
                                      + command = (known after apply)
                                    }
                                  + failureThreshold              = (known after apply)
                                  + grpc                          = {
                                      + port    = (known after apply)
                                      + service = (known after apply)
                                    }
                                  + httpGet                       = {
                                      + host        = (known after apply)
                                      + httpHeaders = (known after apply)
                                      + path        = (known after apply)
                                      + port        = (known after apply)
                                      + scheme      = (known after apply)
                                    }
                                  + initialDelaySeconds           = (known after apply)
                                  + periodSeconds                 = (known after apply)
                                  + successThreshold              = (known after apply)
                                  + tcpSocket                     = {
                                      + host = (known after apply)
                                      + port = (known after apply)
                                    }
                                  + terminationGracePeriodSeconds = (known after apply)
                                  + timeoutSeconds                = (known after apply)
                                }
                              + resources                = {
                                  + limits   = (known after apply)
                                  + requests = (known after apply)
                                }
                              + securityContext          = {
                                  + allowPrivilegeEscalation = (known after apply)
                                  + capabilities             = {
                                      + add  = (known after apply)
                                      + drop = (known after apply)
                                    }
                                  + privileged               = (known after apply)
                                  + procMount                = (known after apply)
                                  + readOnlyRootFilesystem   = (known after apply)
                                  + runAsGroup               = (known after apply)
                                  + runAsNonRoot             = (known after apply)
                                  + runAsUser                = (known after apply)
                                  + seLinuxOptions           = {
                                      + level = (known after apply)
                                      + role  = (known after apply)
                                      + type  = (known after apply)
                                      + user  = (known after apply)
                                    }
                                  + seccompProfile           = {
                                      + localhostProfile = (known after apply)
                                      + type             = (known after apply)
                                    }
                                  + windowsOptions           = {
                                      + gmsaCredentialSpec     = (known after apply)
                                      + gmsaCredentialSpecName = (known after apply)
                                      + hostProcess            = (known after apply)
                                      + runAsUserName          = (known after apply)
                                    }
                                }
                              + startupProbe             = {
                                  + exec                          = {
                                      + command = (known after apply)
                                    }
                                  + failureThreshold              = (known after apply)
                                  + grpc                          = {
                                      + port    = (known after apply)
                                      + service = (known after apply)
                                    }
                                  + httpGet                       = {
                                      + host        = (known after apply)
                                      + httpHeaders = (known after apply)
                                      + path        = (known after apply)
                                      + port        = (known after apply)
                                      + scheme      = (known after apply)
                                    }
                                  + initialDelaySeconds           = (known after apply)
                                  + periodSeconds                 = (known after apply)
                                  + successThreshold              = (known after apply)
                                  + tcpSocket                     = {
                                      + host = (known after apply)
                                      + port = (known after apply)
                                    }
                                  + terminationGracePeriodSeconds = (known after apply)
                                  + timeoutSeconds                = (known after apply)
                                }
                              + stdin                    = (known after apply)
                              + stdinOnce                = (known after apply)
                              + terminationMessagePath   = (known after apply)
                              + terminationMessagePolicy = (known after apply)
                              + tty                      = (known after apply)
                              + volumeDevices            = (known after apply)
                              + volumeMounts             = (known after apply)
                              + workingDir               = (known after apply)
                            },
                        ]
                      + dnsConfig                     = {
                          + nameservers = (known after apply)
                          + options     = (known after apply)
                          + searches    = (known after apply)
                        }
                      + dnsPolicy                     = (known after apply)
                      + enableServiceLinks            = (known after apply)
                      + ephemeralContainers           = (known after apply)
                      + hostAliases                   = (known after apply)
                      + hostIPC                       = (known after apply)
                      + hostNetwork                   = (known after apply)
                      + hostPID                       = (known after apply)
                      + hostname                      = (known after apply)
                      + imagePullSecrets              = (known after apply)
                      + initContainers                = (known after apply)
                      + nodeName                      = (known after apply)
                      + nodeSelector                  = (known after apply)
                      + os                            = {
                          + name = (known after apply)
                        }
                      + overhead                      = (known after apply)
                      + preemptionPolicy              = (known after apply)
                      + priority                      = (known after apply)
                      + priorityClassName             = (known after apply)
                      + readinessGates                = (known after apply)
                      + restartPolicy                 = (known after apply)
                      + runtimeClassName              = (known after apply)
                      + schedulerName                 = (known after apply)
                      + securityContext               = {
                          + fsGroup             = (known after apply)
                          + fsGroupChangePolicy = (known after apply)
                          + runAsGroup          = (known after apply)
                          + runAsNonRoot        = (known after apply)
                          + runAsUser           = (known after apply)
                          + seLinuxOptions      = {
                              + level = (known after apply)
                              + role  = (known after apply)
                              + type  = (known after apply)
                              + user  = (known after apply)
                            }
                          + seccompProfile      = {
                              + localhostProfile = (known after apply)
                              + type             = (known after apply)
                            }
                          + supplementalGroups  = (known after apply)
                          + sysctls             = (known after apply)
                          + windowsOptions      = {
                              + gmsaCredentialSpec     = (known after apply)
                              + gmsaCredentialSpecName = (known after apply)
                              + hostProcess            = (known after apply)
                              + runAsUserName          = (known after apply)
                            }
                        }
                      + serviceAccount                = (known after apply)
                      + serviceAccountName            = (known after apply)
                      + setHostnameAsFQDN             = (known after apply)
                      + shareProcessNamespace         = (known after apply)
                      + subdomain                     = (known after apply)
                      + terminationGracePeriodSeconds = (known after apply)
                      + tolerations                   = (known after apply)
                      + topologySpreadConstraints     = (known after apply)
                      + volumes                       = (known after apply)
                    }
                }
            }
        }

      + field_manager {
          + force_conflicts = false
          + name            = "edamsoft"
        }
    }

  # kubernetes_namespace_v1.turo will be created
  + resource "kubernetes_namespace_v1" "turo" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "eric-testing"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Saved the plan to: tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "tfplan"
