### PR TITLE
FixLinkonIndex Requesting approval to deploy image 6-3faa023

### DIFF
--- a/deploy/deploy.auto.tfvars
+++ b/deploy/deploy.auto.tfvars
@@ -1,6 +1,6 @@
 kube_config_context = "devops-interview"
 deployment_yaml     = "manifests/deploy.yaml"
-image_name          ="docker.io/edamsoft/turo:5-2f05fc7"
+image_name          ="docker.io/edamsoft/turo:6-3faa023"
 kube_namespace      = "eric-testing"
 acm_arn             = "arn:aws:acm:us-east-1:663118211814:certificate/9dc98912-b4aa-48c9-96d7-bf82a5691a10"
 ssl_service_yaml    = "manifests/https_service.yaml"


### PR DESCRIPTION
Please review terraform plan for branch deploy_6-3faa023:
 kubernetes_namespace_v1.turo: Refreshing state... [id=eric-testing]
kubernetes_config_map_v1.config_page: Refreshing state... [id=eric-testing/config-page]
kubernetes_config_map_v1.index_display: Refreshing state... [id=eric-testing/index-display]
kubernetes_manifest.ssl_service: Refreshing state...
kubernetes_manifest.turo-test-deployment: Refreshing state...

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # kubernetes_config_map_v1.config_page will be updated in-place
  ~ resource "kubernetes_config_map_v1" "config_page" {
      ~ data        = {
          ~ "config_values" = <<-EOT
                kube_config_context = "devops-interview"
                deployment_yaml     = "manifests/deploy.yaml"
              - image_name          ="docker.io/edamsoft/turo:5-2f05fc7"
              + image_name          ="docker.io/edamsoft/turo:6-3faa023"
                kube_namespace      = "eric-testing"
                acm_arn             = "arn:aws:acm:us-east-1:663118211814:certificate/9dc98912-b4aa-48c9-96d7-bf82a5691a10"
                ssl_service_yaml    = "manifests/https_service.yaml"
                display_value       = "Explore the world's largest car sharing marketplace"
            EOT
        }
        id          = "eric-testing/config-page"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # kubernetes_manifest.turo-test-deployment will be updated in-place
  ~ resource "kubernetes_manifest" "turo-test-deployment" {
      ~ manifest = {
          ~ spec       = {
              ~ template = {
                  ~ spec     = {
                      ~ containers = [
                          ~ {
                              ~ image = "docker.io/edamsoft/turo:5-2f05fc7" -> "docker.io/edamsoft/turo:6-3faa023"
                                name  = "turo-test"
                                # (1 unchanged element hidden)
                            },
                        ]
                    }
                    # (1 unchanged element hidden)
                }
                # (2 unchanged elements hidden)
            }
            # (3 unchanged elements hidden)
        }
      ~ object   = {
          ~ spec       = {
              ~ template                = {
                  ~ spec     = {
                      ~ containers                    = [
                          ~ {
                              ~ image                    = "docker.io/edamsoft/turo:5-2f05fc7" -> "docker.io/edamsoft/turo:6-3faa023"
                                name                     = "turo-test"
                                # (20 unchanged elements hidden)
                            },
                        ]
                        # (35 unchanged elements hidden)
                    }
                    # (1 unchanged element hidden)
                }
                # (7 unchanged elements hidden)
            }
            # (3 unchanged elements hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Saved the plan to: tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "tfplan"
